### PR TITLE
Limited cv::Mat support in Image class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ build/*.ncb
 build/*.user
 build/*.sln
 build/.vs
-
+.cache
+compile_commands.json

--- a/include/sbl/image/Image.h
+++ b/include/sbl/image/Image.h
@@ -123,6 +123,12 @@ public:
 		}
 		return m_cvMat;
 	}
+	inline const cv::Mat cvMat() const {
+		if (m_cvMat.empty()) {
+			createCvMat();
+		}
+		return m_cvMat;
+	}
 
 private:
 
@@ -130,14 +136,14 @@ private:
     void createIplImage() const;
 
 	/// create cv::Mat object if needed
-	void createCvMat();
+	void createCvMat() const;
 
 	/// the stored IplImage, if any
 	mutable IplImage *m_iplImage;
 	mutable bool m_deallocIplImage;
 
 	/// the stored cv::Mat, if any
-	cv::Mat m_cvMat;
+	mutable cv::Mat m_cvMat;
 
 #endif // USE_OPENCV
 };
@@ -339,6 +345,7 @@ template<typename T, int CHANNEL_COUNT> Image<T, CHANNEL_COUNT>::Image( cv::Mat 
     m_rowBytes = rowWidth * sizeof( T );
     m_raw = (T *) img.data;
     m_cvMat = img;
+	m_iplImage = NULL;
 	m_deleteRaw = false;
 	m_deallocIplImage = false;
 
@@ -354,7 +361,7 @@ template<typename T, int CHANNEL_COUNT> Image<T, CHANNEL_COUNT>::Image( cv::Mat 
 
 
 /// create cv::Mat object if needed
-template<typename T, int CHANNEL_COUNT> void Image<T, CHANNEL_COUNT>::createCvMat() {
+template<typename T, int CHANNEL_COUNT> void Image<T, CHANNEL_COUNT>::createCvMat() const {
     assert( m_cvMat.empty() );
 
 	// determine parameters of cv::Mat constructor

--- a/include/sbl/image/Image.h
+++ b/include/sbl/image/Image.h
@@ -357,20 +357,12 @@ template<typename T, int CHANNEL_COUNT> Image<T, CHANNEL_COUNT>::Image( cv::Mat 
 template<typename T, int CHANNEL_COUNT> void Image<T, CHANNEL_COUNT>::createCvMat() {
     assert( m_cvMat.empty() );
 
-	// determine type
-	int type;
-	if (isFloat()) {
-		type = CV_32FC(CHANNEL_COUNT);
-	} else if (depth() == 8) {
-		type = CV_8UC(CHANNEL_COUNT);
-	} else if (depth() == 16) {
-		type = CV_16UC(CHANNEL_COUNT);
-	} else {
-		type = CV_32SC(CHANNEL_COUNT);
-	}
+	// determine parameters of cv::Mat constructor
+	cv::Size size = cv::Size(m_width, m_height);
+	int type = CV_MAKETYPE(cv::DataType<T>::type, CHANNEL_COUNT);
 
 	// create cv::Mat object
-	m_cvMat = cv::Mat(cv::Size(m_width, m_height), type, m_raw);
+	m_cvMat = cv::Mat(size, type, m_raw);
 }
 
 

--- a/include/sbl/image/Image.h
+++ b/include/sbl/image/Image.h
@@ -109,9 +109,6 @@ public:
 	/// create an Image object wrapping an IplImage object
 	Image( IplImage *iplImage, bool deallocIplImage );
 
-	/// create an Image object wrapping a cv::Mat object
-	Image( cv::Mat img );
-
 	/// return IplImage object; create object if needed
     inline IplImage *iplImage() { if (m_iplImage == NULL) createIplImage(); return m_iplImage; } 
 	inline const IplImage *iplImage() const { if (m_iplImage == NULL) createIplImage(); return m_iplImage; }
@@ -332,31 +329,6 @@ template<typename T, int CHANNEL_COUNT> void Image<T, CHANNEL_COUNT>::createIplI
     m_iplImage->maskROI = NULL;
     m_iplImage->imageId = NULL;
     m_iplImage->tileInfo = NULL;
-}
-
-
-/// create an ImageColor object wrapping a cv::Mat object
-template<typename T, int CHANNEL_COUNT> Image<T, CHANNEL_COUNT>::Image( cv::Mat img ) {
-	assertAlways( img.channels() == CHANNEL_COUNT );
-	assertAlways( img.elemSize1() == sizeof(T) );
-	m_width = img.cols;
-    m_height = img.rows;
-	int rowWidth = img.cols * CHANNEL_COUNT;
-    m_rowBytes = rowWidth * sizeof( T );
-    m_raw = (T *) img.data;
-    m_cvMat = img;
-	m_iplImage = NULL;
-	m_deleteRaw = false;
-	m_deallocIplImage = false;
-
-    // create row pointers
-	m_ptr = new T*[ m_height ];
-	if (m_ptr == NULL) {
-		fatalError( "error allocating ImageColor pointers" );
-	}
-	for (int i = 0; i < m_height; i++) {
-		m_ptr[ i ] = m_raw + i * rowWidth;
-	}
 }
 
 


### PR DESCRIPTION
This PR adds limited `cv::Mat` support to the `Image` class, mainly through a new method called `cvMat()` that behaves like the existing `iplImage()` method.  `cvMat()` returns a `cv::Mat` object that wraps the `m_raw` buffer in `Image`, creating that object if necessary.  Note that image data is not copied when the `cv::Mat` object is created.

This provides a way to get a `cv::Mat` from an `Image`, and I also explored the other direction: having a constructor in the `Image` class that takes a `cv::Mat` as input.  However, I found that this lead to a confusing user experience, because then both `Image` and the `cv::Mat` used to create it could deallocate `m_raw`.  `cv::Mat` is particularly problematic in that respect, because it does not provide a way to shut off the deallocation mechanism (for example, by transferring responsibility for its data pointer to another object).

So while this PR doesn't provide a full solution for transitioning to `cv::Mat`, it should make the process easier by providing a `cv::Mat` interface for reading and writing `Image` objects, while avoiding the need for copying image data.